### PR TITLE
Fix art sub-nav bug preventing changing the category

### DIFF
--- a/src/browser/components/shared/preview/container/PreviewContainer.tsx
+++ b/src/browser/components/shared/preview/container/PreviewContainer.tsx
@@ -29,22 +29,13 @@ interface PreviewContainerProps {
   category?: string;
 }
 
-interface PreviewContainerState {
-  category: string;
-}
-
-export default class PreviewContainer extends React.Component<PreviewContainerProps, PreviewContainerState> {
+export default class PreviewContainer extends React.Component<PreviewContainerProps> {
   static defaultProps = {
     category: ''
   };
 
-  constructor(props: PreviewContainerProps) {
-    super(props);
-    this.state = { category: this.props.category};
-  };
-
   render() {
-    const { category } = this.state;
+    const { category } = this.props;
     return (
       <QueryRenderer
         environment={environment}


### PR DESCRIPTION
I removed the state from this component because it was only copying the props that got updated by react-router when the URL changed.